### PR TITLE
feat: use an in memory nats server and a jetstream consumer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,21 @@ module github.com/simpleiot/nats-exp
 
 go 1.21.1
 
-require github.com/nats-io/nats.go v1.30.2
+require (
+	github.com/nats-io/nats-server/v2 v2.9.21
+	github.com/nats-io/nats.go v1.30.2
+)
 
 require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.21 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
+	github.com/nats-io/jwt/v2 v2.4.1 // indirect
 	github.com/nats-io/nkeys v0.4.5 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=


### PR DESCRIPTION
For the time series benchmark, create an in-process nats server with a temporary jetstream directory.

When consuming the data points, use an ephemeral pull-based consumer acknowledging messages in batches. 